### PR TITLE
Réglage partiel du bug du médallium

### DIFF
--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -138,13 +138,109 @@ class Medallium(commands.Cog) :
                                                     value=yokai_list_formated)
                                 inv_embed.set_author(name=f"Médallium de {user.name}")
                         return await interaction.response.send_message(embed=inv_embed)
+                    #if the medallium is to big to be in one message
                     except discord.errors.HTTPException as e:
-                        error_embed = discord.Embed(color=discord.Color.red(),
-                                                    title="Oh non, une erreur s'est produite !",
-                                                    description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
-                        error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
-                                            value="Vous pouvez utiliser le message ci-dessus.")
-                        return await interaction.response.send_message(embed=error_embed)
+                        try:
+                            if self.values[0] == "Tout !":
+                                yo_kai_show = ["E","D","C"]
+
+                            for classes in yokai_per_class:
+                                yokai_list_brute = yokai_per_class[classes]
+                                classes_name = await Cf.classid_to_class(classes, False)
+                                class_id = classes
+                                
+                                if class_id in yo_kai_show:
+
+                                    yokai_list_formated += f"Rang {classes_name}:\n"
+
+                                    if yokai_list_brute != {}:
+                                        for elements in yokai_list_brute:
+                                            if yokai_list_brute[elements] > 1:
+                                                yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
+                                            else:
+                                                yokai_list_formated += f"> {elements}\n"
+                                    
+                                if class_id == "C":
+                                    #the message for select the page.
+                                    #Page one: Every yo-kai of class E, D and C
+                                    #Page two: Every yo-kai of class B and A
+                                    #Page three: Every yo-kai of class S, tresure, special, legendary, boss, divinity and shiny
+                                    class Inv_dropdown(discord.ui.Select):
+                                        def __init__(self):
+                                            options = [
+                                            discord.SelectOption(label="Page 1", description="Affiche la page 1 du médallium.", emoji="1️⃣"),
+                                            discord.SelectOption(label="Page 2", description="Affiche la page 2 du médallium.", emoji="2️⃣"),
+                                            discord.SelectOption(label="Page 3", description="Affiche la page 3 du médallium.", emoji="3️⃣"),
+                                            ]
+
+                                            super().__init__(placeholder='Choisissez la page du Médallium que vous voulez...', min_values=1, max_values=1, options=options)
+                                        async def callback(self, interaction, ctx=ctx):
+                                            try:
+                                                yokai_list_formated = ""
+                                                if self.values[0] == "Page 1":
+                                                    yo_kai_show = ["E","D","C"]
+                                                elif self.values[0] == "Page 2":
+                                                    yo_kai_show = ["B","A"]
+                                                elif self.values[0] == "Page 3":
+                                                    yo_kai_show = ["S","treasurS","SpecialS", "LegendaryS", "DivinityS", "Boss", "Shiny"]
+
+                                                for classes in yokai_per_class:
+                                                    yokai_list_brute = yokai_per_class[classes]
+                                                    classes_name = await Cf.classid_to_class(classes, False)
+                                                    class_id = classes
+                                
+                                                    if class_id in yo_kai_show:
+
+                                                        yokai_list_formated += f"Rang {classes_name}:\n"
+
+                                                        if yokai_list_brute != {}:
+                                                            for elements in yokai_list_brute:
+                                                                if yokai_list_brute[elements] > 1:
+                                                                    yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
+                                                                else:
+                                                                   yokai_list_formated += f"> {elements}\n"
+                                                inv_embed = discord.Embed(
+                                                    title=f"Voici votre Médallium :",
+                                                    description=yokai_list_formated,
+                                                    color=discord.colour.Color.orange()
+                                                    )
+                                                return await interaction.response.send_message(embed=inv_embed)
+                                            
+                                            #in case there is to many yo-kai, shouldn't be the case but who know?
+                                            except discord.errors.HTTPException:
+                                                error_embed = discord.Embed(color=discord.Color.red(),
+                                                            title="Oh non, une erreur s'est produite !",
+                                                            description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
+                                                error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
+                                                            value="Vous pouvez utiliser le message ci-dessus.")
+                                                return await interaction.response.send_message(embed=error_embed)
+
+
+                                    class Inv_dropdown_view(discord.ui.View):
+                                        def __init__(self):
+                                            super().__init__(timeout=300)
+                                            self.add_item(Inv_dropdown())
+                                            async def on_timeout(self):
+                                                for item in self.children:
+                                                    item.disabled = True
+                                                    try:
+                                                        await self.message.edit( embed=self.message.embeds[0], view=self)
+                                                    except discord.NotFound:
+                                                        pass
+                                    
+                                    Dropdown = Inv_dropdown_view()
+
+                                    main_embed = discord.Embed(title="__Médallium - Page 1__", description=yokai_list_formated,  colour=0xf58f00)
+                                    Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
+
+                        #in case we got another error
+                        except discord.errors.HTTPException:
+                            error_embed = discord.Embed(color=discord.Color.red(),
+                                                        title="Oh non, une erreur s'est produite !",
+                                                        description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
+                            error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
+                                                value="Vous pouvez utiliser le message ci-dessus.")
+                            return await interaction.response.send_message(embed=error_embed)
 
                 else:
                     asked_class = await Cf.classid_to_class(self.values[0], True)

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -144,6 +144,8 @@ class Medallium(commands.Cog) :
                             if self.values[0] == "Tout !":
                                 yo_kai_show = ["E","D","C"]
 
+                            yokai_list_formated = ""
+
                             for classes in yokai_per_class:
                                 yokai_list_brute = yokai_per_class[classes]
                                 classes_name = await Cf.classid_to_class(classes, False)

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -141,101 +141,93 @@ class Medallium(commands.Cog) :
                     #if the medallium is to big to be in one message
                     except discord.errors.HTTPException as e:
                         try:
-                            if self.values[0] == "Tout !":
-                                yo_kai_show = ["E","D","C"]
+                            async def get_yokai_list(yo_kai_show, yokai_per_class):
 
-                            yokai_list_formated = ""
+                                yokai_list_formated = ""
 
-                            for classes in yokai_per_class:
-                                yokai_list_brute = yokai_per_class[classes]
-                                classes_name = await Cf.classid_to_class(classes, False)
-                                class_id = classes
+                                for classes in yokai_per_class:
+                                    yokai_list_brute = yokai_per_class[classes]
+                                    classes_name = await Cf.classid_to_class(classes, False)
+                                    class_id = classes
                                 
-                                if class_id in yo_kai_show:
+                                    if class_id in yo_kai_show:
 
-                                    yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
+                                        yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
 
-                                    if yokai_list_brute != {}:
-                                        for elements in yokai_list_brute:
-                                            if yokai_list_brute[elements] > 1:
-                                                yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
-                                            else:
-                                                yokai_list_formated += f"> {elements}\n"
+                                        if yokai_list_brute != {}:
+                                            for elements in yokai_list_brute:
+                                                if yokai_list_brute[elements] > 1:
+                                                    yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
+                                                else:
+                                                    yokai_list_formated += f"> {elements}\n"
+                                return yokai_list_formated
+                            
+                            
+                            
                                     
-                                if class_id == "C":
-                                    #the message for select the page.
-                                    #Page one: Every yo-kai of class E, D and C
-                                    #Page two: Every yo-kai of class B and A
-                                    #Page three: Every yo-kai of class S, tresure, special, legendary, boss, divinity and shiny
-                                    class Inv_dropdown(discord.ui.Select):
-                                        def __init__(self):
-                                            options = [
-                                            discord.SelectOption(label="Page 1", description="Affiche la page 1 du médallium.", emoji="1️⃣"),
-                                            discord.SelectOption(label="Page 2", description="Affiche la page 2 du médallium.", emoji="2️⃣"),
-                                            discord.SelectOption(label="Page 3", description="Affiche la page 3 du médallium.", emoji="3️⃣"),
-                                            ]
+                            #the message for select the page.
+                            #Page one: Every yo-kai of class E, D and C
+                            #Page two: Every yo-kai of class B and A
+                            #Page three: Every yo-kai of class S, tresure, special, legendary, boss, divinity and shiny
+                            class Inv_all(discord.ui.Select):
+                                def __init__(self):
+                                    options = [
+                                    discord.SelectOption(label="Page 1", description="Affiche la page 1 du médallium.", emoji="1️⃣"),
+                                    discord.SelectOption(label="Page 2", description="Affiche la page 2 du médallium.", emoji="2️⃣"),
+                                    discord.SelectOption(label="Page 3", description="Affiche la page 3 du médallium.", emoji="3️⃣"),
+                                    ]
 
-                                            super().__init__(placeholder='Choisissez la page du Médallium que vous voulez...', min_values=1, max_values=1, options=options)
-                                        async def callback(self, interaction, ctx=ctx):
-                                            try:
-                                                yokai_list_formated = ""
+                                    super().__init__(placeholder='Choisissez la page du Médallium que vous voulez...', min_values=1, max_values=1, options=options)
+                                async def callback(self, interaction, ctx=ctx):
+                                    try:
+                                        #list of classes per pages
+                                        if self.values[0] == "Page 1":
+                                            yo_kai_show = ["E","D", "C"]
+                                        elif self.values[0] == "Page 2":
+                                            yo_kai_show = ["B","A"]
+                                        elif self.values[0] == "Page 3":
+                                            yo_kai_show = ["S","treasurS","SpecialS", "LegendaryS", "DivinityS", "Boss", "Shiny"]
 
-                                                #list of classes per pages
-                                                if self.values[0] == "Page 1":
-                                                    yo_kai_show = ["E","D", "C"]
-                                                elif self.values[0] == "Page 2":
-                                                    yo_kai_show = ["B","A"]
-                                                elif self.values[0] == "Page 3":
-                                                    yo_kai_show = ["S","treasurS","SpecialS", "LegendaryS", "DivinityS", "Boss", "Shiny"]
+                                        yokai_list_formated = await get_yokai_list(yo_kai_show, yokai_per_class)
 
-                                                for classes in yokai_per_class:
-                                                    yokai_list_brute = yokai_per_class[classes]
-                                                    classes_name = await Cf.classid_to_class(classes, False)
-                                                    class_id = classes
-                                
-                                                    if class_id in yo_kai_show:
-
-                                                        yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
-
-                                                        if yokai_list_brute != {}:
-                                                            for elements in yokai_list_brute:
-                                                                if yokai_list_brute[elements] > 1:
-                                                                    yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
-                                                                else:
-                                                                   yokai_list_formated += f"> {elements}\n"
-                                                inv_embed = discord.Embed( #create the embed
-                                                    title=f"__Médallium - {self.values[0]}:__",
-                                                    description=yokai_list_formated,
-                                                    color=discord.colour.Color.orange()
-                                                    )
-                                                return await interaction.message.edit(embed=inv_embed) #change the message send before for not flood the channel
-                                            
-                                            #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
-                                            except discord.errors.HTTPException:
-                                                error_embed = discord.Embed(color=discord.Color.red(),
-                                                            title="Oh non, une erreur s'est produite !",
-                                                            description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
-                                                error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
-                                                            value="Vous pouvez utiliser le message ci-dessus.")
-                                                return await interaction.response.send_message(embed=error_embed)
+                                        #create the embed
+                                        inv_embed = discord.Embed( 
+                                            title=f"__Médallium - {self.values[0]}:__",
+                                            description=yokai_list_formated,
+                                            color=discord.colour.Color.orange()
+                                            )
+                                        return await interaction.message.edit(embed=inv_embed) #change the message send before for not flood the channel
+                                         
+                                    #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
+                                    except discord.errors.HTTPException:
+                                        error_embed = discord.Embed(color=discord.Color.red(),
+                                            title="Oh non, une erreur s'est produite !",
+                                            description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
+                                        error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
+                                            value="Vous pouvez utiliser le message ci-dessus.")
+                                        return await interaction.response.send_message(embed=error_embed)
 
 
-                                    class Inv_dropdown_view(discord.ui.View):
-                                        def __init__(self):
-                                            super().__init__(timeout=300)
-                                            self.add_item(Inv_dropdown())
-                                            async def on_timeout(self):
-                                                for item in self.children:
-                                                    item.disabled = True
-                                                    try:
-                                                        await self.message.edit( embed=self.message.embeds[0], view=self)
-                                                    except discord.NotFound:
-                                                        pass
+                            class Inv_all_view(discord.ui.View):
+                                def __init__(self):
+                                    super().__init__(timeout=300)
+                                    self.add_item(Inv_all())
+                                async def on_timeout(self):
+                                    for item in self.children:
+                                        item.disabled = True
+                                    try:
+                                        await self.message.edit( embed=self.message.embeds[0], view=self)
+                                    except discord.NotFound:
+                                        pass
                                     
-                                    Dropdown = Inv_dropdown_view()
+                            Dropdown = Inv_all_view()
 
-                                    main_embed = discord.Embed(title="__Médallium - Page 1:__", description=yokai_list_formated,  colour=0xf58f00)
-                                    Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
+                            yo_kai_show = ["E","D","C"]
+
+                            yokai_list_formated = await get_yokai_list(yo_kai_show, yokai_per_class)
+
+                            main_embed = discord.Embed(title="__Médallium - Page 1:__", description=yokai_list_formated,  colour=0xf58f00)
+                            Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
 
                         #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
                         except discord.errors.HTTPException:

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -96,17 +96,17 @@ class Medallium(commands.Cog) :
             def __init__(self):
                 options = [
                     discord.SelectOption(label="Tout !", description="Affiche tout le Médallium si possible.", emoji="🌐"),
-                    discord.SelectOption(label="E", emoji="✨"),
-                    discord.SelectOption(label="D", emoji="✨"),
-                    discord.SelectOption(label="C", emoji="✨"),
-                    discord.SelectOption(label="B", emoji="✨"),
-                    discord.SelectOption(label="A", emoji="✨"),
-                    discord.SelectOption(label="S", emoji="✨"),
-                    discord.SelectOption(label="Légendaire", emoji="✨"),
-                    discord.SelectOption(label="Trésor", emoji="✨"),
-                    discord.SelectOption(label="Spécial", emoji="✨"),
-                    discord.SelectOption(label="Divinité / Enma", emoji="✨"),
-                    discord.SelectOption(label="Boss", emoji="✨"),
+                    discord.SelectOption(label="E", emoji=emoji["E"]),
+                    discord.SelectOption(label="D", emoji=emoji["D"]),
+                    discord.SelectOption(label="C", emoji=emoji["C"]),
+                    discord.SelectOption(label="B", emoji=emoji["B"]),
+                    discord.SelectOption(label="A", emoji=emoji["A"]),
+                    discord.SelectOption(label="S", emoji=emoji["S"]),
+                    discord.SelectOption(label="Légendaire", emoji=emoji["LegendaryS"]),
+                    discord.SelectOption(label="Trésor", emoji=emoji["treasureS"]),
+                    discord.SelectOption(label="Spécial", emoji=emoji["SpecialS"]),
+                    discord.SelectOption(label="Divinité / Enma", emoji=emoji["DivinityS"]),
+                    discord.SelectOption(label="Boss", emoji=emoji["Boss"]),
                     discord.SelectOption(label="Shiny", emoji="✨")
                 ]
 

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -96,17 +96,17 @@ class Medallium(commands.Cog) :
             def __init__(self):
                 options = [
                     discord.SelectOption(label="Tout !", description="Affiche tout le Médallium si possible.", emoji="🌐"),
-                    discord.SelectOption(label="E", emoji=emoji["E"]),
-                    discord.SelectOption(label="D", emoji=emoji["D"]),
-                    discord.SelectOption(label="C", emoji=emoji["C"]),
-                    discord.SelectOption(label="B", emoji=emoji["B"]),
-                    discord.SelectOption(label="A", emoji=emoji["A"]),
-                    discord.SelectOption(label="S", emoji=emoji["S"]),
-                    discord.SelectOption(label="Légendaire", emoji=emoji["LegendaryS"]),
-                    discord.SelectOption(label="Trésor", emoji=emoji["treasureS"]),
-                    discord.SelectOption(label="Spécial", emoji=emoji["SpecialS"]),
-                    discord.SelectOption(label="Divinité / Enma", emoji=emoji["DivinityS"]),
-                    discord.SelectOption(label="Boss", emoji=emoji["Boss"]),
+                    discord.SelectOption(label="E", emoji="✨"),
+                    discord.SelectOption(label="D", emoji="✨"),
+                    discord.SelectOption(label="C", emoji="✨"),
+                    discord.SelectOption(label="B", emoji="✨"),
+                    discord.SelectOption(label="A", emoji="✨"),
+                    discord.SelectOption(label="S", emoji="✨"),
+                    discord.SelectOption(label="Légendaire", emoji="✨"),
+                    discord.SelectOption(label="Trésor", emoji="✨"),
+                    discord.SelectOption(label="Spécial", emoji="✨"),
+                    discord.SelectOption(label="Divinité / Enma", emoji="✨"),
+                    discord.SelectOption(label="Boss", emoji="✨"),
                     discord.SelectOption(label="Shiny", emoji="✨")
                 ]
 
@@ -151,7 +151,7 @@ class Medallium(commands.Cog) :
                                 
                                 if class_id in yo_kai_show:
 
-                                    yokai_list_formated += f"Rang {classes_name}:\n"
+                                    yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
 
                                     if yokai_list_brute != {}:
                                         for elements in yokai_list_brute:
@@ -177,8 +177,10 @@ class Medallium(commands.Cog) :
                                         async def callback(self, interaction, ctx=ctx):
                                             try:
                                                 yokai_list_formated = ""
+
+                                                #list of classes per pages
                                                 if self.values[0] == "Page 1":
-                                                    yo_kai_show = ["E","D","C"]
+                                                    yo_kai_show = ["E","D", "C"]
                                                 elif self.values[0] == "Page 2":
                                                     yo_kai_show = ["B","A"]
                                                 elif self.values[0] == "Page 3":
@@ -191,7 +193,7 @@ class Medallium(commands.Cog) :
                                 
                                                     if class_id in yo_kai_show:
 
-                                                        yokai_list_formated += f"Rang {classes_name}:\n"
+                                                        yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
 
                                                         if yokai_list_brute != {}:
                                                             for elements in yokai_list_brute:
@@ -199,15 +201,16 @@ class Medallium(commands.Cog) :
                                                                     yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
                                                                 else:
                                                                    yokai_list_formated += f"> {elements}\n"
-                                                inv_embed = discord.Embed(
-                                                    title=f"Voici votre Médallium :",
+                                                inv_embed = discord.Embed( #create the embed
+                                                    title=f"__Médallium - {self.values[0]}:__",
                                                     description=yokai_list_formated,
                                                     color=discord.colour.Color.orange()
                                                     )
-                                                return await interaction.response.send_message(embed=inv_embed)
+                                                return await interaction.message.edit(embed=inv_embed) #change the message send before for not flood the channel
                                             
-                                            #in case there is to many yo-kai, shouldn't be the case but who know?
-                                            except discord.errors.HTTPException:
+                                            #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
+                                            except discord.errors.HTTPException as e:
+                                                print(e)
                                                 error_embed = discord.Embed(color=discord.Color.red(),
                                                             title="Oh non, une erreur s'est produite !",
                                                             description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
@@ -230,11 +233,12 @@ class Medallium(commands.Cog) :
                                     
                                     Dropdown = Inv_dropdown_view()
 
-                                    main_embed = discord.Embed(title="__Médallium - Page 1__", description=yokai_list_formated,  colour=0xf58f00)
+                                    main_embed = discord.Embed(title="__Médallium - Page 1:__", description=yokai_list_formated,  colour=0xf58f00)
                                     Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
 
-                        #in case we got another error
-                        except discord.errors.HTTPException:
+                        #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
+                        except discord.errors.HTTPException as e:
+                            print(e)
                             error_embed = discord.Embed(color=discord.Color.red(),
                                                         title="Oh non, une erreur s'est produite !",
                                                         description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -209,8 +209,7 @@ class Medallium(commands.Cog) :
                                                 return await interaction.message.edit(embed=inv_embed) #change the message send before for not flood the channel
                                             
                                             #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
-                                            except discord.errors.HTTPException as e:
-                                                print(e)
+                                            except discord.errors.HTTPException:
                                                 error_embed = discord.Embed(color=discord.Color.red(),
                                                             title="Oh non, une erreur s'est produite !",
                                                             description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
@@ -237,8 +236,7 @@ class Medallium(commands.Cog) :
                                     Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
 
                         #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
-                        except discord.errors.HTTPException as e:
-                            print(e)
+                        except discord.errors.HTTPException:
                             error_embed = discord.Embed(color=discord.Color.red(),
                                                         title="Oh non, une erreur s'est produite !",
                                                         description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")


### PR DESCRIPTION
Règle partiellement le bug qui provient quand on essaye d'afficher tout le médallium, mais ne fonctionne toujours pas sur ceux trop gros.
L'ancien format est toujours présent, le nouveau se déclenche uniquement en cas d'erreur.
Le message d'erreur est toujours présent.

https://github.com/user-attachments/assets/c68259ad-4955-4ae9-801d-65912ab4225e

