### PR TITLE
Bingo-kai chanceux

### DIFF
--- a/bot_package/data.py
+++ b/bot_package/data.py
@@ -69,6 +69,7 @@ with open("./files/yokai_list.json") as yokai_list:
 class_list = ['E', 'D', 'C', 'B', 'A', 'S', 'LegendaryS', "treasureS", "SpecialS", 'DivinityS', "Boss", "Shiny"]
 proba_list = [0.4165, 0.2, 0.12, 0.12, 0.08, 0.04, 0.0075, 0.0075, 0.0075, 0.005, 0.0025, 0.0010]
 #                E     D     C     B     A     S      L       t       Sp      D       B      Sh
+golden_proba_list = [0.0, 0.2, 0.2, 0.2, 0.15, 0.1, 0.05, 0.05, 0.005, 0.025, 0.01, 0.01]
 
 
 #Get the full list

--- a/cogs/bingo-kai.py
+++ b/cogs/bingo-kai.py
@@ -150,7 +150,7 @@ class Bingo_kai(commands.Cog):
                 return await ctx.send(embed=error_embed)
         
             if amount > 6 :
-                proba = amount / ProbaT #constant
+                proba = amount / probaT #constant
                 anti_proba = 1 - proba
                 if random.choices([True, False], weights=[proba, anti_proba])[0]:
                     error_embed = discord.Embed(title="Oh non, vous avez fait votre maximum de tirage avec des pièces pour aujourd'hui...", description="Recommencez demain !")
@@ -694,7 +694,7 @@ class Bingo_kai(commands.Cog):
                 message = random.choice(["La V6 est là: fais /help pour plus d'info !","Regardes le top 10 avec /top !","Regardes ton rang avec /rank !","Combien d'orbes as tu ? Regardes avec /orbe !"])
                 yokai_embed.set_footer(text=message)
             await ctx.send(embed=yokai_embed)
-            return await ctx.send(embed=coin_embed)
+            await ctx.send(embed=coin_embed)
 
         
         else :
@@ -764,9 +764,54 @@ class Bingo_kai(commands.Cog):
         await Cf.save_inv(inventory_history, ctx.author.id)
         if streak_embed:
             await ctx.send(embed=streak_embed)
+    
+        #choose to give or not the coin
+        winning_bingo_kai = random.choices([True, False], weights = [0.01,0.99])
 
-                
+        winning_bingo_kai = True
+        if winning_bingo_kai:
+            winning_bkai_embed = discord.Embed(
+            title="Tu as reçu l'accès à un tirage au bingo kai doré!",
+            description="Fait /bingo-kai-gagnant pour utiliser ton tirage!",
+            color=discord.Color.yellow()
+            )
             
+            brute_bag = await Cf.get_bag(ctx.author.id)
+            verification = True
+            
+            #check if the bag is empty
+            if brute_bag == {} :
+                brute_bag = {
+                    "coin" : 1,
+                    "obj" : 0,
+                    "treasure" : 0,
+                    "golden coin" : ["coin"]
+                }
+                verification = False
+            
+            if verification == True:
+                #get all the coins
+                for elements in brute_bag.keys():
+                    if elements == "Pièce gagnante":
+                        #stack the coin
+                        try:
+                        #stack the Yo-kai
+                            brute_bag["Pièce gagnante"][1] += 1
+                        except IndexError:
+                            brute_bag["Pièce gagnante"].append(2)
+                        verification = False
+
+                if verification == True:  
+                    brute_bag["Pièce gagnante"] = ["coin"]
+                    brute_bag["coin"] += 1
+            
+            #gold_bkai_embed.set_thumbnail(url="")
+
+            await Cf.save_bag(brute_bag, ctx.author.id)
+            await ctx.send(embed=winning_bkai_embed)
+            
+            
+
 
     
     @commands.hybrid_command(name="bkai")
@@ -777,6 +822,149 @@ class Bingo_kai(commands.Cog):
         """
         await self.bingo_yokai(ctx, coin)
 
+
+    @commands.hybrid_command(name="bingo-kai-gagnant")
+    async def bingo_kai_gagnant(self, ctx = commands.Context):
+        """
+        Tire au sort un Yo-kai de manière aléatoire, mais avec de meilleur yo-kai que le bingo-kai classique
+        Pour utiliser la commande, vous devez posséder un tirage (obtenable dans le bingo-kai)
+        """
+            
+        brute_inventory = await Cf.get_inv(ctx.author.id)
+        brute_bag = await Cf.get_bag(ctx.author.id)
+
+        #look if there is a golden coin, else return that there isn't one
+        try:
+            brute_bag["Pièce gagnante"]
+        except KeyError:
+            not_has = discord.Embed(
+                title=f"Tu n'as pas de pièce gagnante :/",
+                color=discord.Color.orange()
+            )
+            self.bot.logger.info(
+                f"Executed bingo-kai-gagnant command by {ctx.author} (ID: {ctx.author.id}) but he didn't have a golden coin"
+                )
+            return await ctx.send(embed=not_has)
+
+        #remove the coin
+        try:
+            if brute_bag["Pièce gagnante"][1] > 2:
+                brute_bag["Pièce gagnante"][1] -= 1
+            elif brute_bag["Pièce gagnante"][1] == 2:
+                brute_bag["Pièce gagnante"].remove(brute_bag["Pièce gagnante"][1])
+        except IndexError:
+            brute_bag.pop("Pièce gagnante")
+            brute_bag["coin"] -= 1
+
+
+        weights=data.golden_proba_list.copy() #will do a bingo-kai roll, but with better luck
+        class_choice = data.yokai_data[random.choices(data.class_list, weights=weights, k=1)[0]]
+        while class_choice["class_name"] in data.blacklist["rang"]:
+            class_choice = data.yokai_data[random.choices(data.class_list, weights=weights, k=1)[0]]
+
+        #get the good name of the class and his id
+        class_name = class_choice.get("class_name")
+        class_id = class_choice.get("class_id")
+        #choose the Yo-kai in the class
+        Yokai_choice = random.choice(class_choice["yokai_list"])
+        
+        while Yokai_choice in data.blacklist.get("yokai") :
+            Yokai_choice = random.choice(class_choice["yokai_list"])
+        Yokai_choice = Yokai_choice
+
+        yokai_embed = discord.Embed(
+            title=f"Vous avez eu le Yo-kai **{Yokai_choice}** ✨ ",
+            description=f"Félicitations il est de rang **{class_name}**",
+            color=discord.Color.from_str(data.yokai_data[class_id]["color"])
+        )
+        yokai_embed.set_thumbnail(url=data.image_link[class_id])
+        
+        #define the id and so the api request to the image
+        
+
+        id = data.yokai_list_full.get(Yokai_choice, {}).get("id", None)
+        yokai_embed.set_image(url=f"https://api.quark-dev.com/yk/img/{id}.png")
+
+        if id == None :
+            yokai_embed.add_field(name="Image non disponible ! 😢", inline=False, value="En effet, nous ne possédons pas l'image de tous les Yo-kai, mais l'équipe travaille pour les apporter au complet et au plus vite.")
+
+        #logs the roll
+        if ctx.guild is not None:
+            self.bot.logger.info(
+                f"Executed bingo-kai-gagnant command in {ctx.guild.name} (ID: {ctx.guild.id}) by {ctx.author} (ID: {ctx.author.id}) // He had '{Yokai_choice}' / Rank: {class_name}"
+            )
+        else:
+            self.bot.logger.info(
+                f"Executed bingo-kai-gagnant command by {ctx.author} (ID: {ctx.author.id}) in DMs // He had '{Yokai_choice}' / Rank: {class_name}"
+                )
+
+
+        #is the Yo-kai in the inventory
+        verification = True
+
+        if verification == True:
+            #get all the yokais
+            for elements in brute_inventory.keys():
+                if elements == Yokai_choice:
+                    verification = False
+                    try:
+                    #stack the Yo-kai
+                        brute_inventory[Yokai_choice][1] += 1
+                    except IndexError:
+                        brute_inventory[Yokai_choice].append(2)
+
+                    #Generate the embed
+                    yokai_embed.add_field(
+                        name=f"Vous l'avez déjà eu. Vous en avez donc {brute_inventory[Yokai_choice][1]}",
+                        value="Faites `/medallium` pour voir votre Médallium."
+                        )
+                    #SAVE the inv
+                    await Cf.save_inv(brute_inventory, ctx.author.id)
+
+                    #add orbe depending of the class
+                    await eco.add_rank_orbe(ctx.author.id, class_id)
+                    yokai_embed.add_field(name="vous l'avez déjà eu, dommage.",
+                                value=f"voici {data.class_to_point[class_id]} orbes oni en cadeau."
+                                )                               
+                    
+            
+            if verification == True:
+                brute_inventory[Yokai_choice] = [class_id]
+            try:
+                brute_inventory[class_id] += 1
+            except KeyError:
+                brute_inventory[class_id] = 1
+            await Cf.save_inv(brute_inventory, ctx.author.id)
+            yokai_embed.add_field(
+                name="Vous ne l'avez jamais eu ! 🆕",
+                value="Il a été ajouté a votre Médallium. Faites `/medallium` pour le voir."
+            )
+
+        else:
+            brute_inventory[Yokai_choice] = [class_id]
+            try:
+                brute_inventory[class_id] += 1
+            except KeyError:
+                brute_inventory[class_id] = 1
+            await Cf.save_inv(brute_inventory, ctx.author.id)
+            yokai_embed.add_field(
+                name="Vous ne l'avez jamais eu ! 🆕",
+                value="Il a été ajouté a votre Médallium. Faites `/medallium` pour le voir."
+            )
+        message = random.choice(["La V6 est là: fais /help pour plus d'info !","Regardes le top 10 avec /top !","Regardes ton rang avec /rank !","Combien d'orbes as tu ? Regardes avec /orbe !"])
+        yokai_embed.set_footer(text=message)
+        yokai_embed.set_footer(text="Tu as utilisé un tirage du bingo-kai gagnant!")
+                
+        await Cf.save_bag(brute_bag, ctx.author.id)
+        return await ctx.send(embed=yokai_embed)
+
+
+    @commands.hybrid_command(name="bkai-gagnant")
+    async def bkai_gagnant(self, ctx = commands.Context):
+        """
+        Alias de /bingo-kai-gagnant.
+        """
+        await self.bingo_kai_gagnant(ctx)
     
 async def setup(bot) -> None:
     await bot.add_cog(Bingo_kai(bot))

--- a/cogs/bingo-kai.py
+++ b/cogs/bingo-kai.py
@@ -768,7 +768,6 @@ class Bingo_kai(commands.Cog):
         #choose to give or not the coin
         winning_bingo_kai = random.choices([True, False], weights = [0.01,0.99])
 
-        winning_bingo_kai = True
         if winning_bingo_kai:
             winning_bkai_embed = discord.Embed(
             title="Tu as reçu l'accès à un tirage au bingo kai doré!",

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -138,13 +138,109 @@ class Medallium(commands.Cog) :
                                                     value=yokai_list_formated)
                                 inv_embed.set_author(name=f"Médallium de {user.name}")
                         return await interaction.response.send_message(embed=inv_embed)
+                    #if the medallium is to big to be in one message
                     except discord.errors.HTTPException as e:
-                        error_embed = discord.Embed(color=discord.Color.red(),
-                                                    title="Oh non, une erreur s'est produite !",
-                                                    description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
-                        error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
-                                            value="Vous pouvez utiliser le message ci-dessus.")
-                        return await interaction.response.send_message(embed=error_embed)
+                        try:
+                            if self.values[0] == "Tout !":
+                                yo_kai_show = ["E","D","C"]
+
+                            for classes in yokai_per_class:
+                                yokai_list_brute = yokai_per_class[classes]
+                                classes_name = await Cf.classid_to_class(classes, False)
+                                class_id = classes
+                                
+                                if class_id in yo_kai_show:
+
+                                    yokai_list_formated += f"Rang {classes_name}:\n"
+
+                                    if yokai_list_brute != {}:
+                                        for elements in yokai_list_brute:
+                                            if yokai_list_brute[elements] > 1:
+                                                yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
+                                            else:
+                                                yokai_list_formated += f"> {elements}\n"
+                                    
+                                if class_id == "C":
+                                    #the message for select the page.
+                                    #Page one: Every yo-kai of class E, D and C
+                                    #Page two: Every yo-kai of class B and A
+                                    #Page three: Every yo-kai of class S, tresure, special, legendary, boss, divinity and shiny
+                                    class Inv_dropdown(discord.ui.Select):
+                                        def __init__(self):
+                                            options = [
+                                            discord.SelectOption(label="Page 1", description="Affiche la page 1 du médallium.", emoji="1️⃣"),
+                                            discord.SelectOption(label="Page 2", description="Affiche la page 2 du médallium.", emoji="2️⃣"),
+                                            discord.SelectOption(label="Page 3", description="Affiche la page 3 du médallium.", emoji="3️⃣"),
+                                            ]
+
+                                            super().__init__(placeholder='Choisissez la page du Médallium que vous voulez...', min_values=1, max_values=1, options=options)
+                                        async def callback(self, interaction, ctx=ctx):
+                                            try:
+                                                yokai_list_formated = ""
+                                                if self.values[0] == "Page 1":
+                                                    yo_kai_show = ["E","D","C"]
+                                                elif self.values[0] == "Page 2":
+                                                    yo_kai_show = ["B","A"]
+                                                elif self.values[0] == "Page 3":
+                                                    yo_kai_show = ["S","treasurS","SpecialS", "LegendaryS", "DivinityS", "Boss", "Shiny"]
+
+                                                for classes in yokai_per_class:
+                                                    yokai_list_brute = yokai_per_class[classes]
+                                                    classes_name = await Cf.classid_to_class(classes, False)
+                                                    class_id = classes
+                                
+                                                    if class_id in yo_kai_show:
+
+                                                        yokai_list_formated += f"Rang {classes_name}:\n"
+
+                                                        if yokai_list_brute != {}:
+                                                            for elements in yokai_list_brute:
+                                                                if yokai_list_brute[elements] > 1:
+                                                                    yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
+                                                                else:
+                                                                   yokai_list_formated += f"> {elements}\n"
+                                                inv_embed = discord.Embed(
+                                                    title=f"Voici votre Médallium :",
+                                                    description=yokai_list_formated,
+                                                    color=discord.colour.Color.orange()
+                                                    )
+                                                return await interaction.response.send_message(embed=inv_embed)
+                                            
+                                            #in case there is to many yo-kai, shouldn't be the case but who know?
+                                            except discord.errors.HTTPException:
+                                                error_embed = discord.Embed(color=discord.Color.red(),
+                                                            title="Oh non, une erreur s'est produite !",
+                                                            description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
+                                                error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
+                                                            value="Vous pouvez utiliser le message ci-dessus.")
+                                                return await interaction.response.send_message(embed=error_embed)
+
+
+                                    class Inv_dropdown_view(discord.ui.View):
+                                        def __init__(self):
+                                            super().__init__(timeout=300)
+                                            self.add_item(Inv_dropdown())
+                                            async def on_timeout(self):
+                                                for item in self.children:
+                                                    item.disabled = True
+                                                    try:
+                                                        await self.message.edit( embed=self.message.embeds[0], view=self)
+                                                    except discord.NotFound:
+                                                        pass
+                                    
+                                    Dropdown = Inv_dropdown_view()
+
+                                    main_embed = discord.Embed(title="__Médallium - Page 1__", description=yokai_list_formated,  colour=0xf58f00)
+                                    Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
+
+                        #in case we got another error
+                        except discord.errors.HTTPException:
+                            error_embed = discord.Embed(color=discord.Color.red(),
+                                                        title="Oh non, une erreur s'est produite !",
+                                                        description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
+                            error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
+                                                value="Vous pouvez utiliser le message ci-dessus.")
+                            return await interaction.response.send_message(embed=error_embed)
 
                 else:
                     asked_class = await Cf.classid_to_class(self.values[0], True)

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -144,6 +144,8 @@ class Medallium(commands.Cog) :
                             if self.values[0] == "Tout !":
                                 yo_kai_show = ["E","D","C"]
 
+                            yokai_list_formated = ""
+
                             for classes in yokai_per_class:
                                 yokai_list_brute = yokai_per_class[classes]
                                 classes_name = await Cf.classid_to_class(classes, False)

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -141,101 +141,93 @@ class Medallium(commands.Cog) :
                     #if the medallium is to big to be in one message
                     except discord.errors.HTTPException as e:
                         try:
-                            if self.values[0] == "Tout !":
-                                yo_kai_show = ["E","D","C"]
+                            async def get_yokai_list(yo_kai_show, yokai_per_class):
 
-                            yokai_list_formated = ""
+                                yokai_list_formated = ""
 
-                            for classes in yokai_per_class:
-                                yokai_list_brute = yokai_per_class[classes]
-                                classes_name = await Cf.classid_to_class(classes, False)
-                                class_id = classes
+                                for classes in yokai_per_class:
+                                    yokai_list_brute = yokai_per_class[classes]
+                                    classes_name = await Cf.classid_to_class(classes, False)
+                                    class_id = classes
                                 
-                                if class_id in yo_kai_show:
+                                    if class_id in yo_kai_show:
 
-                                    yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
+                                        yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
 
-                                    if yokai_list_brute != {}:
-                                        for elements in yokai_list_brute:
-                                            if yokai_list_brute[elements] > 1:
-                                                yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
-                                            else:
-                                                yokai_list_formated += f"> {elements}\n"
+                                        if yokai_list_brute != {}:
+                                            for elements in yokai_list_brute:
+                                                if yokai_list_brute[elements] > 1:
+                                                    yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
+                                                else:
+                                                    yokai_list_formated += f"> {elements}\n"
+                                return yokai_list_formated
+                            
+                            
+                            
                                     
-                                if class_id == "C":
-                                    #the message for select the page.
-                                    #Page one: Every yo-kai of class E, D and C
-                                    #Page two: Every yo-kai of class B and A
-                                    #Page three: Every yo-kai of class S, tresure, special, legendary, boss, divinity and shiny
-                                    class Inv_dropdown(discord.ui.Select):
-                                        def __init__(self):
-                                            options = [
-                                            discord.SelectOption(label="Page 1", description="Affiche la page 1 du médallium.", emoji="1️⃣"),
-                                            discord.SelectOption(label="Page 2", description="Affiche la page 2 du médallium.", emoji="2️⃣"),
-                                            discord.SelectOption(label="Page 3", description="Affiche la page 3 du médallium.", emoji="3️⃣"),
-                                            ]
+                            #the message for select the page.
+                            #Page one: Every yo-kai of class E, D and C
+                            #Page two: Every yo-kai of class B and A
+                            #Page three: Every yo-kai of class S, tresure, special, legendary, boss, divinity and shiny
+                            class Inv_all(discord.ui.Select):
+                                def __init__(self):
+                                    options = [
+                                    discord.SelectOption(label="Page 1", description="Affiche la page 1 du médallium.", emoji="1️⃣"),
+                                    discord.SelectOption(label="Page 2", description="Affiche la page 2 du médallium.", emoji="2️⃣"),
+                                    discord.SelectOption(label="Page 3", description="Affiche la page 3 du médallium.", emoji="3️⃣"),
+                                    ]
 
-                                            super().__init__(placeholder='Choisissez la page du Médallium que vous voulez...', min_values=1, max_values=1, options=options)
-                                        async def callback(self, interaction, ctx=ctx):
-                                            try:
-                                                yokai_list_formated = ""
+                                    super().__init__(placeholder='Choisissez la page du Médallium que vous voulez...', min_values=1, max_values=1, options=options)
+                                async def callback(self, interaction, ctx=ctx):
+                                    try:
+                                        #list of classes per pages
+                                        if self.values[0] == "Page 1":
+                                            yo_kai_show = ["E","D", "C"]
+                                        elif self.values[0] == "Page 2":
+                                            yo_kai_show = ["B","A"]
+                                        elif self.values[0] == "Page 3":
+                                            yo_kai_show = ["S","treasurS","SpecialS", "LegendaryS", "DivinityS", "Boss", "Shiny"]
 
-                                                #list of classes per pages
-                                                if self.values[0] == "Page 1":
-                                                    yo_kai_show = ["E","D", "C"]
-                                                elif self.values[0] == "Page 2":
-                                                    yo_kai_show = ["B","A"]
-                                                elif self.values[0] == "Page 3":
-                                                    yo_kai_show = ["S","treasurS","SpecialS", "LegendaryS", "DivinityS", "Boss", "Shiny"]
+                                        yokai_list_formated = await get_yokai_list(yo_kai_show, yokai_per_class)
 
-                                                for classes in yokai_per_class:
-                                                    yokai_list_brute = yokai_per_class[classes]
-                                                    classes_name = await Cf.classid_to_class(classes, False)
-                                                    class_id = classes
-                                
-                                                    if class_id in yo_kai_show:
-
-                                                        yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
-
-                                                        if yokai_list_brute != {}:
-                                                            for elements in yokai_list_brute:
-                                                                if yokai_list_brute[elements] > 1:
-                                                                    yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
-                                                                else:
-                                                                   yokai_list_formated += f"> {elements}\n"
-                                                inv_embed = discord.Embed( #create the embed
-                                                    title=f"__Médallium - {self.values[0]}:__",
-                                                    description=yokai_list_formated,
-                                                    color=discord.colour.Color.orange()
-                                                    )
-                                                return await interaction.message.edit(embed=inv_embed) #change the message send before for not flood the channel
-                                            
-                                            #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
-                                            except discord.errors.HTTPException:
-                                                error_embed = discord.Embed(color=discord.Color.red(),
-                                                            title="Oh non, une erreur s'est produite !",
-                                                            description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
-                                                error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
-                                                            value="Vous pouvez utiliser le message ci-dessus.")
-                                                return await interaction.response.send_message(embed=error_embed)
+                                        #create the embed
+                                        inv_embed = discord.Embed( 
+                                            title=f"__Médallium - {self.values[0]}:__",
+                                            description=yokai_list_formated,
+                                            color=discord.colour.Color.orange()
+                                            )
+                                        return await interaction.message.edit(embed=inv_embed) #change the message send before for not flood the channel
+                                         
+                                    #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
+                                    except discord.errors.HTTPException:
+                                        error_embed = discord.Embed(color=discord.Color.red(),
+                                            title="Oh non, une erreur s'est produite !",
+                                            description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
+                                        error_embed.add_field(name="Vous devez donc spécifier un rang pour que cela marche.",
+                                            value="Vous pouvez utiliser le message ci-dessus.")
+                                        return await interaction.response.send_message(embed=error_embed)
 
 
-                                    class Inv_dropdown_view(discord.ui.View):
-                                        def __init__(self):
-                                            super().__init__(timeout=300)
-                                            self.add_item(Inv_dropdown())
-                                            async def on_timeout(self):
-                                                for item in self.children:
-                                                    item.disabled = True
-                                                    try:
-                                                        await self.message.edit( embed=self.message.embeds[0], view=self)
-                                                    except discord.NotFound:
-                                                        pass
+                            class Inv_all_view(discord.ui.View):
+                                def __init__(self):
+                                    super().__init__(timeout=300)
+                                    self.add_item(Inv_all())
+                                async def on_timeout(self):
+                                    for item in self.children:
+                                        item.disabled = True
+                                    try:
+                                        await self.message.edit( embed=self.message.embeds[0], view=self)
+                                    except discord.NotFound:
+                                        pass
                                     
-                                    Dropdown = Inv_dropdown_view()
+                            Dropdown = Inv_all_view()
 
-                                    main_embed = discord.Embed(title="__Médallium - Page 1:__", description=yokai_list_formated,  colour=0xf58f00)
-                                    Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
+                            yo_kai_show = ["E","D","C"]
+
+                            yokai_list_formated = await get_yokai_list(yo_kai_show, yokai_per_class)
+
+                            main_embed = discord.Embed(title="__Médallium - Page 1:__", description=yokai_list_formated,  colour=0xf58f00)
+                            Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
 
                         #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
                         except discord.errors.HTTPException:

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -96,17 +96,17 @@ class Medallium(commands.Cog) :
             def __init__(self):
                 options = [
                     discord.SelectOption(label="Tout !", description="Affiche tout le Médallium si possible.", emoji="🌐"),
-                    discord.SelectOption(label="E", emoji="✨"),
-                    discord.SelectOption(label="D", emoji="✨"),
-                    discord.SelectOption(label="C", emoji="✨"),
-                    discord.SelectOption(label="B", emoji="✨"),
-                    discord.SelectOption(label="A", emoji="✨"),
-                    discord.SelectOption(label="S", emoji="✨"),
-                    discord.SelectOption(label="Légendaire", emoji="✨"),
-                    discord.SelectOption(label="Trésor", emoji="✨"),
-                    discord.SelectOption(label="Spécial", emoji="✨"),
-                    discord.SelectOption(label="Divinité / Enma", emoji="✨"),
-                    discord.SelectOption(label="Boss", emoji="✨"),
+                    discord.SelectOption(label="E", emoji=emoji["E"]),
+                    discord.SelectOption(label="D", emoji=emoji["D"]),
+                    discord.SelectOption(label="C", emoji=emoji["C"]),
+                    discord.SelectOption(label="B", emoji=emoji["B"]),
+                    discord.SelectOption(label="A", emoji=emoji["A"]),
+                    discord.SelectOption(label="S", emoji=emoji["S"]),
+                    discord.SelectOption(label="Légendaire", emoji=emoji["LegendaryS"]),
+                    discord.SelectOption(label="Trésor", emoji=emoji["treasureS"]),
+                    discord.SelectOption(label="Spécial", emoji=emoji["SpecialS"]),
+                    discord.SelectOption(label="Divinité / Enma", emoji=emoji["DivinityS"]),
+                    discord.SelectOption(label="Boss", emoji=emoji["Boss"]),
                     discord.SelectOption(label="Shiny", emoji="✨")
                 ]
 

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -96,17 +96,17 @@ class Medallium(commands.Cog) :
             def __init__(self):
                 options = [
                     discord.SelectOption(label="Tout !", description="Affiche tout le Médallium si possible.", emoji="🌐"),
-                    discord.SelectOption(label="E", emoji=emoji["E"]),
-                    discord.SelectOption(label="D", emoji=emoji["D"]),
-                    discord.SelectOption(label="C", emoji=emoji["C"]),
-                    discord.SelectOption(label="B", emoji=emoji["B"]),
-                    discord.SelectOption(label="A", emoji=emoji["A"]),
-                    discord.SelectOption(label="S", emoji=emoji["S"]),
-                    discord.SelectOption(label="Légendaire", emoji=emoji["LegendaryS"]),
-                    discord.SelectOption(label="Trésor", emoji=emoji["treasureS"]),
-                    discord.SelectOption(label="Spécial", emoji=emoji["SpecialS"]),
-                    discord.SelectOption(label="Divinité / Enma", emoji=emoji["DivinityS"]),
-                    discord.SelectOption(label="Boss", emoji=emoji["Boss"]),
+                    discord.SelectOption(label="E", emoji="✨"),
+                    discord.SelectOption(label="D", emoji="✨"),
+                    discord.SelectOption(label="C", emoji="✨"),
+                    discord.SelectOption(label="B", emoji="✨"),
+                    discord.SelectOption(label="A", emoji="✨"),
+                    discord.SelectOption(label="S", emoji="✨"),
+                    discord.SelectOption(label="Légendaire", emoji="✨"),
+                    discord.SelectOption(label="Trésor", emoji="✨"),
+                    discord.SelectOption(label="Spécial", emoji="✨"),
+                    discord.SelectOption(label="Divinité / Enma", emoji="✨"),
+                    discord.SelectOption(label="Boss", emoji="✨"),
                     discord.SelectOption(label="Shiny", emoji="✨")
                 ]
 
@@ -151,7 +151,7 @@ class Medallium(commands.Cog) :
                                 
                                 if class_id in yo_kai_show:
 
-                                    yokai_list_formated += f"Rang {classes_name}:\n"
+                                    yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
 
                                     if yokai_list_brute != {}:
                                         for elements in yokai_list_brute:
@@ -177,8 +177,10 @@ class Medallium(commands.Cog) :
                                         async def callback(self, interaction, ctx=ctx):
                                             try:
                                                 yokai_list_formated = ""
+
+                                                #list of classes per pages
                                                 if self.values[0] == "Page 1":
-                                                    yo_kai_show = ["E","D","C"]
+                                                    yo_kai_show = ["E","D", "C"]
                                                 elif self.values[0] == "Page 2":
                                                     yo_kai_show = ["B","A"]
                                                 elif self.values[0] == "Page 3":
@@ -191,7 +193,7 @@ class Medallium(commands.Cog) :
                                 
                                                     if class_id in yo_kai_show:
 
-                                                        yokai_list_formated += f"Rang {classes_name}:\n"
+                                                        yokai_list_formated += f"# __**Rang {classes_name}:**__\n"
 
                                                         if yokai_list_brute != {}:
                                                             for elements in yokai_list_brute:
@@ -199,15 +201,16 @@ class Medallium(commands.Cog) :
                                                                     yokai_list_formated += f"> {elements} **`(x{str(yokai_list_brute[elements])})`**\n"
                                                                 else:
                                                                    yokai_list_formated += f"> {elements}\n"
-                                                inv_embed = discord.Embed(
-                                                    title=f"Voici votre Médallium :",
+                                                inv_embed = discord.Embed( #create the embed
+                                                    title=f"__Médallium - {self.values[0]}:__",
                                                     description=yokai_list_formated,
                                                     color=discord.colour.Color.orange()
                                                     )
-                                                return await interaction.response.send_message(embed=inv_embed)
+                                                return await interaction.message.edit(embed=inv_embed) #change the message send before for not flood the channel
                                             
-                                            #in case there is to many yo-kai, shouldn't be the case but who know?
-                                            except discord.errors.HTTPException:
+                                            #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
+                                            except discord.errors.HTTPException as e:
+                                                print(e)
                                                 error_embed = discord.Embed(color=discord.Color.red(),
                                                             title="Oh non, une erreur s'est produite !",
                                                             description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
@@ -230,11 +233,12 @@ class Medallium(commands.Cog) :
                                     
                                     Dropdown = Inv_dropdown_view()
 
-                                    main_embed = discord.Embed(title="__Médallium - Page 1__", description=yokai_list_formated,  colour=0xf58f00)
+                                    main_embed = discord.Embed(title="__Médallium - Page 1:__", description=yokai_list_formated,  colour=0xf58f00)
                                     Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
 
-                        #in case we got another error
-                        except discord.errors.HTTPException:
+                        #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
+                        except discord.errors.HTTPException as e:
+                            print(e)
                             error_embed = discord.Embed(color=discord.Color.red(),
                                                         title="Oh non, une erreur s'est produite !",
                                                         description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")

--- a/cogs/medallium.py
+++ b/cogs/medallium.py
@@ -209,8 +209,7 @@ class Medallium(commands.Cog) :
                                                 return await interaction.message.edit(embed=inv_embed) #change the message send before for not flood the channel
                                             
                                             #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
-                                            except discord.errors.HTTPException as e:
-                                                print(e)
+                                            except discord.errors.HTTPException:
                                                 error_embed = discord.Embed(color=discord.Color.red(),
                                                             title="Oh non, une erreur s'est produite !",
                                                             description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")
@@ -237,8 +236,7 @@ class Medallium(commands.Cog) :
                                     Dropdown.message = await ctx.send(embed=main_embed, view=Dropdown)
 
                         #in case there is to many yo-kai, shouldn't be the case but who know? Edit: it's the case for nearly 100% medallium
-                        except discord.errors.HTTPException as e:
-                            print(e)
+                        except discord.errors.HTTPException:
                             error_embed = discord.Embed(color=discord.Color.red(),
                                                         title="Oh non, une erreur s'est produite !",
                                                         description="> Un bug sur cette commande se produit quand le Médallium est trop grand pour être affiché. (C'est un peu un flex quand même 🙃)")


### PR DESCRIPTION
Ajout du bingo-kai chanceux, un bingo-kai qui a 1% de chance d'apparaitre lors d'un /bkai .Il faut faire un /bkai-chanceux pour le déclencher, et il a de meilleur proba de yo-kai que le bingo-kai classique. (d'ailleurs jsp pk ça veut mettre les trucs du médallium)